### PR TITLE
Improve factorial solution

### DIFF
--- a/Iterators and Closures/Standard Library Types/Factorial/src/lib.rs
+++ b/Iterators and Closures/Standard Library Types/Factorial/src/lib.rs
@@ -1,8 +1,3 @@
 pub fn factorial(num: u64) -> u64 {
-    if num == 1 {
-        return 1;
-    }
-    else {
-        num*factorial(num-1)
-    }
+    (1..=num).fold(1, |acc, x| acc * x)
 }


### PR DESCRIPTION
This solution treats the range as an iterator, and uses `fold` to calculate the factorial answer.

The existing solution breaks the rule of not using `return` as specified in the task description. Also, it uses recursion.

From the task:
> For the most fun don't use:
>  * Recursion

Here's the diff against the original solution when viewed with 'Peek Solution...' in the Task view:

![Screen Shot 2020-01-19 at 01 11 23](https://user-images.githubusercontent.com/117291/72672833-abad0f00-3a58-11ea-96a0-39dbd1ff59e0.png)
