### PR TITLE
feat(Common Programming Concepts - Data Types - Slices): Book referen…

### DIFF
--- a/Common Programming Concepts/Data Types/Slices/task.md
+++ b/Common Programming Concepts/Data Types/Slices/task.md
@@ -7,6 +7,6 @@ Get a slice out of Array so that the `if` statement returns `true`.
   https://doc.rust-lang.org/book/ch04-03-slices.html
   and use the starting and ending indices of the items in the Array that you want to end up in the slice.
 
-  If you're curious why the right hand of the `==` comparison does not have an ampersand for a reference since the left hand side is a reference, take a look at the Deref coercions section of the book:
-  https://doc.rust-lang.org/book/ch15-02-deref.html
+  If you're curious why the right hand of the `==` comparison does not have an ampersand for a reference since the left hand side is a reference, take a look at the
+  <a href ="https://doc.rust-lang.org/book/ch15-02-deref.html">Deref coercions section of the book</a>.
 </div>


### PR DESCRIPTION
…ce formatting fixed in the hint

The book reference in the hint is surrounded with <a> tag.

Closes https://github.com/jetbrains-academy/rustlings-course/issues/23