### PR TITLE
fix(Type Conversions - Type Conversions - AsRef and AsMut): A placeho…

### DIFF
--- a/Type Conversions/Type Conversions/AsRef and AsMut/task-info.yaml
+++ b/Type Conversions/Type Conversions/AsRef and AsMut/task-info.yaml
@@ -6,13 +6,13 @@ files:
   - offset: 21
     length: 12
     placeholder_text: |-
-      // Obtain the number of bytes (not characters) in the given argument
-      // Add the AsRef trait appropriately as a trait bound
+      /*Obtain the number of bytes (not characters) in the given argument
+       Add the AsRef trait appropriately as a trait bound*/
   - offset: 113
     length: 12
     placeholder_text: |-
-      // Obtain the number of characters (not bytes) in the given argument
-      // Add the AsRef trait appropriately as a trait bound
+      /* Obtain the number of characters (not bytes) in the given argument
+       Add the AsRef trait appropriately as a trait bound*/
 - name: src/main.rs
   visible: true
 - name: Cargo.toml


### PR DESCRIPTION
…lders; fix

The comment formatting fixed in two of the placeholders to avoid thw
whole lines being commented after the placeholder text

Closes EDC-362