### PR TITLE
Format code block as such

### DIFF
--- a/Common Programming Concepts/Variables/Shadowing/task.md
+++ b/Common Programming Concepts/Variables/Shadowing/task.md
@@ -29,9 +29,10 @@ Shadowing is different from marking a variable as `mut`, because we’ll get a c
 
 The other difference between `mut` and shadowing is that because we’re effectively creating a new variable when we use the `let` keyword again, we can change the type of the value but reuse the same name. For example, say our program asks a user to show how many spaces they want between some text by inputting space characters, but we really want to store that input as a number:
 
-
+```rust
 let spaces = "   ";
 let spaces = spaces.len();
+```
 
 This construct is allowed because the first `spaces` variable is a string type and the second `spaces` variable, which is a brand-new variable that happens to have the same name as the first one, is a number type. Shadowing thus spares us from having to come up with different names, such as `spaces_str` and `spaces_num`; instead, we can reuse the simpler spaces name. However, if we try to use mut for this, as shown here, we’ll get a compile-time error:
 


### PR DESCRIPTION
Not sure why the last line shows up as changed - edited the source in Github UI and assume it automatically added/removed a trailing line break at the last line