### PR TITLE
Remove the redundant unit field

### DIFF
--- a/Common Programming Concepts/Conditions/lesson-remote-info.yaml
+++ b/Common Programming Concepts/Conditions/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271624
 update_date: Thu, 31 Oct 2019 15:20:05 UTC
-unit: 252668

--- a/Common Programming Concepts/Functions/lesson-remote-info.yaml
+++ b/Common Programming Concepts/Functions/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271622
 update_date: Thu, 31 Oct 2019 15:19:48 UTC
-unit: 252666

--- a/Common Programming Concepts/Variables, Functions, and Conditions Test/lesson-remote-info.yaml
+++ b/Common Programming Concepts/Variables, Functions, and Conditions Test/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 2062649995
 update_date: Thu, 01 Jan 1970 00:00:00 UTC
-unit: 0

--- a/Common Programming Concepts/Variables/lesson-remote-info.yaml
+++ b/Common Programming Concepts/Variables/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271620
 update_date: Thu, 31 Oct 2019 15:19:17 UTC
-unit: 252664

--- a/Concurrency/Threads/lesson-remote-info.yaml
+++ b/Concurrency/Threads/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271635
 update_date: Thu, 31 Oct 2019 15:21:45 UTC
-unit: 252679

--- a/Data Types/Enums and Pattern Matching/lesson-remote-info.yaml
+++ b/Data Types/Enums and Pattern Matching/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 457176416
 update_date: Thu, 01 Jan 1970 00:00:00 UTC
-unit: 0

--- a/Data Types/Structs/lesson-remote-info.yaml
+++ b/Data Types/Structs/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 816380957
 update_date: Thu, 01 Jan 1970 00:00:00 UTC
-unit: 0

--- a/Error Handling/Error Handling/lesson-remote-info.yaml
+++ b/Error Handling/Error Handling/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271631
 update_date: Thu, 31 Oct 2019 15:21:05 UTC
-unit: 252675

--- a/Generic Types, Traits, and Lifetime/Generic Types, Traits, and Lifetime/lesson-remote-info.yaml
+++ b/Generic Types, Traits, and Lifetime/Generic Types, Traits, and Lifetime/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 1777884666
 update_date: Thu, 01 Jan 1970 00:00:00 UTC
-unit: 0

--- a/Introduction/Getting started/lesson-remote-info.yaml
+++ b/Introduction/Getting started/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271619
 update_date: Thu, 31 Oct 2019 15:19:11 UTC
-unit: 252663

--- a/Macros/Macros Test/lesson-remote-info.yaml
+++ b/Macros/Macros Test/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 548825968
 update_date: Thu, 01 Jan 1970 00:00:00 UTC
-unit: 0

--- a/Macros/Macros/lesson-remote-info.yaml
+++ b/Macros/Macros/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271627
 update_date: Thu, 31 Oct 2019 15:20:37 UTC
-unit: 252671

--- a/Modules/Modules/lesson-remote-info.yaml
+++ b/Modules/Modules/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271626
 update_date: Thu, 31 Oct 2019 15:20:27 UTC
-unit: 252670

--- a/Standard Library Types/Iterators and Closures/lesson-remote-info.yaml
+++ b/Standard Library Types/Iterators and Closures/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271634
 update_date: Thu, 31 Oct 2019 15:21:35 UTC
-unit: 252678

--- a/Standard Library Types/Type Conversions/lesson-remote-info.yaml
+++ b/Standard Library Types/Type Conversions/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 262040317
 update_date: Thu, 01 Jan 1970 00:00:00 UTC
-unit: 0

--- a/Vectors, Hashmaps, and Strings/String Test/lesson-remote-info.yaml
+++ b/Vectors, Hashmaps, and Strings/String Test/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271630
 update_date: Thu, 31 Oct 2019 15:20:59 UTC
-unit: 252674

--- a/Vectors, Hashmaps, and Strings/Strings/lesson-remote-info.yaml
+++ b/Vectors, Hashmaps, and Strings/Strings/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271629
 update_date: Thu, 31 Oct 2019 15:20:52 UTC
-unit: 252673

--- a/Writing Automated Tests/Tests Test/lesson-remote-info.yaml
+++ b/Writing Automated Tests/Tests Test/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271633
 update_date: Thu, 31 Oct 2019 15:21:31 UTC
-unit: 252677

--- a/Writing Automated Tests/Tests/lesson-remote-info.yaml
+++ b/Writing Automated Tests/Tests/lesson-remote-info.yaml
@@ -1,3 +1,2 @@
 id: 271632
 update_date: Thu, 31 Oct 2019 15:21:22 UTC
-unit: 252676


### PR DESCRIPTION
This is needed to make "Course Preview" work in the recent EDU-tools plugin version.