### PR TITLE
Disable some warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags=["-Adead_code", "-Aunused_variables"]


### PR DESCRIPTION
I want to suppress several warnings in the compiler's output because they are too annoying and useless. This won't affect IDE, there are no good solutions to do that in IDE reporting anyway.