### PR TITLE
fix: rename plugin name

### DIFF
--- a/Introduction/Getting started/Navigating Around/task.md
+++ b/Introduction/Getting started/Navigating Around/task.md
@@ -1,15 +1,15 @@
-## EduTools plugin overview
+## JetBrains Academy plugin overview
 
-This lesson will help you take your first steps with the [EduTools plugin](https://www.jetbrains.com/help/education/educational-products.html) and use it to learn Rust.
+This lesson will help you take your first steps with the [JetBrains Academy plugin](https://www.jetbrains.com/help/education/educational-products.html) and use it to learn Rust.
 
-With the EduTools plugin, you can learn programming languages and tools by completing coding tasks, and get instant feedback right inside the IDE.
+With the JetBrains Academy plugin, you can learn programming languages and tools by completing coding tasks, and get instant feedback right inside the IDE.
 
 Enough talking – let's get started!
 
 If you're already familiar with the interface, you can skip this lesson.
 
 ### Working with courses
-Every course available in EduTools is structured as a list of lessons. Lessons, in turn, can be grouped into sections. Each lesson contains several tasks.
+Every course available in JetBrains Academy is structured as a list of lessons. Lessons, in turn, can be grouped into sections. Each lesson contains several tasks.
 
 When you open a course, you will see the main tool windows used for navigation: <b>Course View</b>, <b>Editor</b>, and <b>Task Description</b>:
 


### PR DESCRIPTION
rename plugin name from the old "EduTools" to "JetBrains Academy"