### PR TITLE
Update Getting Started/External Linter

### DIFF
--- a/Introduction/Getting started/External Linter/task.md
+++ b/Introduction/Getting started/External Linter/task.md
@@ -2,10 +2,10 @@
 
 IntelliJ Rust plugin doesn't detect all the errors. It relies on the Rust compiler to do that. While you are learning Rust, it is useful to see errors as you type. To have this behavior, we recommend to enable an external linter as follows:
 
-1. Go to **Settings / Preferences | Languages & Frameworks | Rust | External Linters** (or directly **Settings / Preferences | Rust | External Linters** if opened in RustRover).
+1. Go to **Settings / Preferences | Rust | External Linters** (or directly **Settings / Preferences | Rust | External Linters** if opened in RustRover).
 2. Set the parameters as follows: 
     - Select **Cargo Check** in the **External Tool:** list;
-    - Check the **Run external linter to analyze code on the fly** checkbox.
+    - Check the **Run external linter on the fly** checkbox.
 
 ![External Linters](images/external-linters.png)
 3. Press **OK**.


### PR DESCRIPTION
The Settings page has been refreshed with Rust being a top level point. Also the checkbox has been updated. These changes reflect that.