### PR TITLE
Fix wrong image in Understanding Ownership/References and Borrowing/Borrowing Values with References

### DIFF
--- a/Understanding Ownership/References and Borrowing/Borrowing Values with References/task.md
+++ b/Understanding Ownership/References and Borrowing/Borrowing Values with References/task.md
@@ -22,7 +22,7 @@ First, notice that all the tuple code in the variable declaration and the functi
 
 These ampersands are _references_, and they allow you to refer to some value without taking ownership of it. Figure 5 shows a diagram.
 
-<img alt="&amp;String s pointing at String s1" src="https://doc.rust-lang.org/stable/book/img/trpl04-05.svg" class="center">
+<img alt="&amp;String s pointing at String s1" src="https://doc.rust-lang.org/stable/book/img/trpl04-06.svg" class="center">
 
 ##### Figure 5: A diagram of &String s pointing at String s1
 


### PR DESCRIPTION
## Before PR:
![screenshot](https://github.com/user-attachments/assets/13376bca-3f46-42ea-a47b-feaf24e144f9)

## After PR:
![screenshot](https://github.com/user-attachments/assets/aa87511b-9215-43cc-a199-4e078cc5d676)

## Reference (in https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html):
![screenshot](https://github.com/user-attachments/assets/69300090-ebbf-45db-a4ff-ee674c3b0a42)
