### PR TITLE
Fix wrong image in Understanding Ownership/The Slice Type/String Slices

### DIFF
--- a/Understanding Ownership/The Slice Type/String Slices/task.md
+++ b/Understanding Ownership/The Slice Type/String Slices/task.md
@@ -15,7 +15,7 @@ We can create slices using a range within brackets by specifying `[starting_inde
 
 Figure 6 shows this in a diagram.
 
-<img alt="world containing a pointer to the 6th byte of String s and a length 5" src="https://doc.rust-lang.org/stable/book/img/trpl04-06.svg" class="center" style="width: 50%;">
+<img alt="world containing a pointer to the 6th byte of String s and a length 5" src="https://doc.rust-lang.org/stable/book/img/trpl04-07.svg" class="center" style="width: 50%;">
 
 ##### Figure 6: String slice referring to part of a String
 


### PR DESCRIPTION
## Before PR:

![image](https://github.com/user-attachments/assets/e36dfe8a-83ad-45f5-a9c0-be63f20fd165)


## After PR:
![image](https://github.com/user-attachments/assets/670a8896-292a-4270-8b28-8fb2d8c1d85b)

## Reference (in https://doc.rust-lang.org/book/ch04-03-slices.html):

![screenshot](https://github.com/user-attachments/assets/2b8c15c4-2086-470e-864d-8831b4eb79ca)