### PR TITLE
Add a reference to the array type task

### DIFF
--- a/Understanding Ownership/References and Borrowing/Print Months Once Again/task.md
+++ b/Understanding Ownership/References and Borrowing/Print Months Once Again/task.md
@@ -5,6 +5,10 @@ Something strange is going on here. The program is compiled without any problems
 Refactor this program to avoid array copying by switching to a mutable reference in `fn print_months_reversed` and fix the compiler errors.
 
 <div class="hint">
+  Remember as we discussed in <a href="course://Common Programming Concepts/Tuples and Arrays/The Array Type">The Array Type</a> task, arrays are allocated on the stack.
+</div>
+
+<div class="hint">
 The first step would be to change the type of argument in <code>fn print_months_reversed</code>.
 </div>
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/EDC-1166/Learn-Rust-References-and-Borrowing-Explain-why-ownership-is-not-transferred