### PR TITLE
Fix typo "you code" -> "your code"

### DIFF
--- a/Common Collections/Strings/Summary/src/main.rs
+++ b/Common Collections/Strings/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Common Collections/Vectors/Intro/src/main.rs
+++ b/Common Collections/Vectors/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Error Handling/Error Handling/A Shortcut for Propagating Errors/src/main.rs
+++ b/Error Handling/Error Handling/A Shortcut for Propagating Errors/src/main.rs
@@ -22,5 +22,5 @@ fn read_username_from_file_3() -> Result<String, io::Error> {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Error Handling/Error Handling/Propagating Errors/src/main.rs
+++ b/Error Handling/Error Handling/Propagating Errors/src/main.rs
@@ -19,5 +19,5 @@ fn read_username_from_file() -> Result<String, io::Error> {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Error Handling/Error Handling/Summary/src/main.rs
+++ b/Error Handling/Error Handling/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Fearless Concurrency/Shared-State Concurrency/Similarities Between RefCell-Rc and Mutex-Arc/src/main.rs
+++ b/Fearless Concurrency/Shared-State Concurrency/Similarities Between RefCell-Rc and Mutex-Arc/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Fearless Concurrency/Shared-State Concurrency/Using Mutexes/src/main.rs
+++ b/Fearless Concurrency/Shared-State Concurrency/Using Mutexes/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Fearless Concurrency/Using Threads to Run Code Simultaneously/Intro/src/main.rs
+++ b/Fearless Concurrency/Using Threads to Run Code Simultaneously/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Generic Data Types/In Enum Definitions/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Generic Data Types/In Enum Definitions/src/main.rs
@@ -9,5 +9,5 @@ enum Result<T, E> {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Generic Data Types/Intro/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Generic Data Types/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Lifetimes/Generic Type Parameters, Trait Bounds, and Lifetimes Together/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Lifetimes/Generic Type Parameters, Trait Bounds, and Lifetimes Together/src/main.rs
@@ -17,5 +17,5 @@ fn longest_with_an_announcement<'a, T>(
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Lifetimes/Lifetime Annotation Syntax/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Lifetimes/Lifetime Annotation Syntax/src/main.rs
@@ -5,5 +5,5 @@ fn lifetime_examples<'a>() {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Lifetimes/Lifetime Annotations in Method Definitions/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Lifetimes/Lifetime Annotations in Method Definitions/src/main.rs
@@ -18,5 +18,5 @@ impl<'a> ImportantExcerpt<'a> {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Lifetimes/Lifetime Elision/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Lifetimes/Lifetime Elision/src/main.rs
@@ -17,5 +17,5 @@ fn first_word(s: &str) -> &str {
 
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Lifetimes/Summary/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Lifetimes/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Lifetimes/Thinking in Terms of Lifetimes/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Lifetimes/Thinking in Terms of Lifetimes/src/main.rs
@@ -9,5 +9,5 @@ fn longest2<'a>(x: &str, y: &str) -> &'a str {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Traits/Defining a Trait/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Traits/Defining a Trait/src/main.rs
@@ -3,5 +3,5 @@ pub trait Summary {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Traits/Returning Types that Implement Traits/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Traits/Returning Types that Implement Traits/src/main.rs
@@ -28,5 +28,5 @@ fn returns_summarizable() -> impl Summary {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Generic Types, Traits, and Lifetime/Traits/Traits as Parameters/src/main.rs
+++ b/Generic Types, Traits, and Lifetime/Traits/Traits as Parameters/src/main.rs
@@ -27,5 +27,5 @@ fn some_function2<T, U>(t: &T, u: &U) -> i32
 { 0 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Introduction/Getting started/External Linter/src/main.rs
+++ b/Introduction/Getting started/External Linter/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Macros/Intro/The Difference Between Macros and Functions/src/main.rs
+++ b/Macros/Intro/The Difference Between Macros and Functions/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Macros/Procedural Macros/Attribute-like macros/src/main.rs
+++ b/Macros/Procedural Macros/Attribute-like macros/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Macros/Procedural Macros/Function-like macros/src/main.rs
+++ b/Macros/Procedural Macros/Function-like macros/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Macros/Procedural Macros/Procedural Macros for Generating Code from Attributes/src/main.rs
+++ b/Macros/Procedural Macros/Procedural Macros for Generating Code from Attributes/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Macros/Procedural Macros/Summary/src/main.rs
+++ b/Macros/Procedural Macros/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Modules/Modules/Bringing Paths into Scope with the use Keyword/runConfigurations/Build.run.xml
+++ b/Modules/Modules/Bringing Paths into Scope with the use Keyword/runConfigurations/Build.run.xml
@@ -1,15 +1,16 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Build bringing_paths_into_scope_with_the_use_keyword" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="dev" />
     <option name="command" value="build -p bringing_paths_into_scope_with_the_use_keyword" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
-    <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/Modules/Modules/Summary/src/main.rs
+++ b/Modules/Modules/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Modules/Modules/The Glob Operator/src/main.rs
+++ b/Modules/Modules/The Glob Operator/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::*;
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Modules/Modules/Using Nested Paths to Clean Up Large use Lists/src/main.rs
+++ b/Modules/Modules/Using Nested Paths to Clean Up Large use Lists/src/main.rs
@@ -7,5 +7,5 @@ use std::{cmp::Ordering, io};
 use std::fs::{self, File};
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Standard Library Types/Closures/Intro/src/main.rs
+++ b/Standard Library Types/Closures/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Standard Library Types/Closures/Moving Captured Values Out of the Closure and the Fn Traits/src/main.rs
+++ b/Standard Library Types/Closures/Moving Captured Values Out of the Closure and the Fn Traits/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Standard Library Types/Closures/unwrap_or_else/src/main.rs
+++ b/Standard Library Types/Closures/unwrap_or_else/src/main.rs
@@ -16,5 +16,5 @@ impl<T> Option<T> {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Standard Library Types/Smart Pointers/Intro/src/main.rs
+++ b/Standard Library Types/Smart Pointers/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Structs, Methods, Enums, and Pattern Matching/Pattern Matching/Matches Are Exhaustive/src/main.rs
+++ b/Structs, Methods, Enums, and Pattern Matching/Pattern Matching/Matches Are Exhaustive/src/main.rs
@@ -6,5 +6,5 @@ fn plus_one(x: Option<i32>) -> Option<i32> {
 }
 
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Structs, Methods, Enums, and Pattern Matching/Pattern Matching/Summary/src/main.rs
+++ b/Structs, Methods, Enums, and Pattern Matching/Pattern Matching/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Structs, Methods, Enums, and Pattern Matching/Structs with Methods/Intro/src/main.rs
+++ b/Structs, Methods, Enums, and Pattern Matching/Structs with Methods/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Structs, Methods, Enums, and Pattern Matching/Structs with Methods/Summary/src/main.rs
+++ b/Structs, Methods, Enums, and Pattern Matching/Structs with Methods/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Understanding Ownership/References and Borrowing/The Rules of References/src/main.rs
+++ b/Understanding Ownership/References and Borrowing/The Rules of References/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Understanding Ownership/The Slice Type/Summary/src/main.rs
+++ b/Understanding Ownership/The Slice Type/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Understanding Ownership/What is ownership/Intro/src/main.rs
+++ b/Understanding Ownership/What is ownership/Intro/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/Writing Automated Tests/Running and Organizing Tests/Summary/src/main.rs
+++ b/Writing Automated Tests/Running and Organizing Tests/Summary/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    // put you code here to launch it
+    // put your code here to launch it
 }

--- a/course-info.yaml
+++ b/course-info.yaml
@@ -46,4 +46,4 @@ additional_files:
   - name: Cargo.toml
   - name: Cargo.lock
   - name: change-notes.txt
-yaml_version: 2
+yaml_version: 5


### PR DESCRIPTION
Fix a typo that was bugging me in the course

Also update YAML version/config ordering - changes made automatically by RustRover.